### PR TITLE
fix(ha): disable aiohttp 4 MiB WS message cap

### DIFF
--- a/src/mylo/ha/ws_client.py
+++ b/src/mylo/ha/ws_client.py
@@ -387,8 +387,11 @@ class HaWsClient:
         self._state = State.CONNECTING
         log.info("ha.ws.connecting", url=self._ws_url)
 
+        # max_msg_size=0 disables aiohttp's 4 MiB cap. HA registry list
+        # responses on large installs (10k+ entities) routinely exceed it
+        # and the connection dies with close code 1009 mid-startup.
         async with self._session.ws_connect(
-            self._ws_url, heartbeat=self._heartbeat, autoclose=True
+            self._ws_url, heartbeat=self._heartbeat, autoclose=True, max_msg_size=0
         ) as ws:
             self._ws = ws
             await self._authenticate(ws)
@@ -459,7 +462,14 @@ class HaWsClient:
                 log.info("ha.ws.server_closed")
                 return
             elif msg.type is aiohttp.WSMsgType.ERROR:
-                raise HaError(f"ws error: {ws.exception()!r}")
+                # ws.exception() is often None on protocol-level errors
+                # (e.g. MESSAGE_TOO_BIG); the actual WebSocketError is on
+                # msg.data. Surface all of it so failures are debuggable
+                # without an ad-hoc repro.
+                raise HaError(
+                    f"ws error: data={msg.data!r} extra={msg.extra!r} "
+                    f"exc={ws.exception()!r} close_code={ws.close_code!r}"
+                )
 
     async def _dispatch(self, data: dict[str, Any]) -> None:
         msg_type = data.get("type")


### PR DESCRIPTION
## Summary

- Pass `max_msg_size=0` to `aiohttp.ClientSession.ws_connect` in `HaWsClient._connect_once` so the HA registry payload isn't truncated on large installs.
- Improve the `WSMsgType.ERROR` log line to include `msg.data`, `msg.extra`, and `ws.close_code`, since `ws.exception()` is `None` on protocol-level errors and the previous `"ws error: None"` made remote diagnosis impossible.

## The bug

Large HA installs (10k+ entities) hit aiohttp's default 4 MiB WebSocket frame limit during the startup registry fetch. Reproduced on a real instance with 11,092 entities, where `config/entity_registry/list` returns ~7.4 MB:

```
WSMessage(type=ERROR, data=WebSocketError(<WSCloseCode.MESSAGE_TOO_BIG: 1009>,
  'Message size 7413394 exceeds limit 4194304'))
```

When this fires:
1. The aiohttp WS closes with code 1009.
2. The runner's `finally` block fails every in-flight `_pending` future with `ConnectionClosed("reconnecting")`.
3. `_startup` is awaiting one of those futures (via `Registries.attach` → `refresh()`), doesn't catch `ConnectionClosed`, and the exception escapes `web.run_app`.
4. The Python process exits, the s6-overlay container exits, Supervisor restarts the container, and the addon crash-loops forever — never serving the UI.

The diagnostic log was misleading: `ws.exception()` is `None` for this aiohttp code path (the `WebSocketError` lives on `msg.data`), so the addon log only said `"ws error: None"` with no clue about message size or close code.

## Fix

Two-line change in `src/mylo/ha/ws_client.py`:
- `_connect_once`: add `max_msg_size=0` to `ws_connect`. HA's own server-side websocket has no message size limit; matching it here is the right call. (A bounded value would also work but any cap re-introduces the same failure on slightly larger installs.)
- `_read_loop`: log `msg.data`, `msg.extra`, `ws.exception()`, and `ws.close_code` together so future failures are debuggable from logs alone.

## Test plan

- [x] `ruff check src tests` and `ruff format --check src tests` clean
- [x] `mypy` clean (99 source files)
- [x] `pytest tests/unit` — 344 passed
- [x] Verified end-to-end on hass-4 (11,092 entities, 819 devices, HA 2026.4.3): addon starts cleanly, `server.started` event fires, container stable across multiple restarts. Pre-fix: tight crash-loop with `ConnectionClosed: reconnecting` traceback every ~1.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)